### PR TITLE
Bugfix/build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,12 @@ all: \
      root_check \
      start_apt_cacher_ng \
      build_adore_if_ros_msg\
-     build_adore_if_ros\
-     build_adore_if_v2x \
      build_adore_v2x_sim \
+     build_adore_if_v2x \
+     build_sumo_if_ros \
      build_plotlabserver \
      build_libadore\
-     build_sumo_if_ros \
+     build_adore_if_ros\
      get_apt_cacher_ng_cache_statistics\
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ USER := $(shell whoami)
 UID := $(shell id -u)
 GID := $(shell id -g)
 
-TEST_SCENARIOS?=baseline_test.launch baseline_test1.launch
+TEST_SCENARIOS?=baseline_test.launch baseline_test.launch
 
 
 .PHONY: all

--- a/adore_if_ros/.dockerignore
+++ b/adore_if_ros/.dockerignore
@@ -4,3 +4,5 @@ Makefile
 **.docker
 **.lizard_report.xml
 **_report.log
+**_docker
+make_gadgets

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,32 +1,14 @@
 version: '3.3'
 
 services:
-  plotlab_server:
-    privileged: true
-    image: plotlabserver:latest
-    container_name: plotlabserver
-    hostname: plotlabserver
-    network_mode: "host"
-    ipc: "host"
-    #entrypoint: sh -c '(xeyes &) && ./plotlabserver'
-    #entrypoint: sh -c 'tail -f /dev/null'
-    build:
-      context: ./plotlabserver
-      dockerfile: Dockerfile.plotlabserver
+  plotlabserver:
+    extends:
+      file: plotlabserver/plotlabserver.yaml
+      service: plotlabserver
     environment:
-      - DISPLAY_MODE=${DISPLAY_MODE:-native}
-     # - DISPLAY_MODE=${DISPLAY_MODE:-window_manager}
-     # - DISPLAY_MODE=${DISPLAY_MODE:-headless}
-      - DISPLAY=${DISPLAY}
-     # - LIBGL_ALWAYS_SOFTWARE=1
-      - QT_X11_NO_MITSHM=1
-    ports:
-      - 12345:12345
-      - 12346:12346
-      - 12347:12347
-    volumes:
-      - /tmp/.X11-unix:/tmp/.X11-unix
-      - .log/plotlabserver:/var/log/plotlab
+      # - DISPLAY_MODE=${DISPLAY_MODE:-native}
+       - DISPLAY_MODE=${DISPLAY_MODE:-window_manager}
+      # - DISPLAY_MODE=${DISPLAY_MODE:-headless}
   ros-master:
     image: ros:noetic-ros-core
     container_name: ros-master
@@ -37,8 +19,8 @@ services:
       - "ROS_HOME=/tmp/adore/.log/.ros"
       - "ROS_MASTER_URI=http://127.0.0.1:11311"
       - "ROS_HOSTNAME=127.0.0.1"
-    volumes:
-        - .ros:/tmp/adore/.ros
+    #volumes:
+    #    - .ros:/tmp/adore/.ros
   adore-cli:
     privileged: true
     image: adore-cli:latest
@@ -48,6 +30,7 @@ services:
     network_mode: "host"
     command: /bin/bash -c "bash tools/adore-cli_start.sh"
     environment:
+      - TEST_SCENARIOS=${TEST_SCENARIOS:-baseline_test.launch}
       - "ADORE_SOURCE_DIR=/tmp/adore"
       - "BAG_OUTPUT_DIRECTORY=/tmp/adore/.log/.ros/bag_files"
       - "ROS_HOME=/tmp/adore/.log/.ros"
@@ -56,7 +39,7 @@ services:
       - "ROS_HOSTNAME=127.0.0.1"
     depends_on:
       # - ros-master  #activate this option if you want to start roscore on startup of adore-cli container
-       - plotlab_server  #activate this option if you want to start plotlabserver automatically with adore-cli container
+       - plotlabserver  #activate this option if you want to start plotlabserver automatically with adore-cli container
     build:
       context: .
       network: host

--- a/docker/Dockerfile.adore-cli
+++ b/docker/Dockerfile.adore-cli
@@ -8,6 +8,7 @@ ARG USER=adore-cli
 ARG UID
 ARG GID
 
+ARG TEST_SCENARIOS
 
 FROM adore_if_ros:latest AS adore-cli
 
@@ -16,6 +17,8 @@ ARG DEBUG
 ARG USER=adore-cli
 ARG UID
 ARG GID
+
+ARG TEST_SCENARIOS
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y xterm vim netcat net-tools && \

--- a/libadore/.dockerignore
+++ b/libadore/.dockerignore
@@ -4,6 +4,4 @@ libdore/external/*/build
 **/build
 **lizard_report.xml
 make_gadgets
-cppcheck
-cpplint
-lizard
+**_docker

--- a/tools/run_test_scenarios.sh
+++ b/tools/run_test_scenarios.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+function echoerr { echo "$@" >&2; exit 1;}
+
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+
+ADORE_ROOT_DIR="$(realpath ${SCRIPT_DIR}/..)"
+LOG_DIR="${ADORE_ROOT_DIR}/.log"
+ROS_LOG_DIR="${LOG_DIR}/.ros/log"
+PLOTLABSERVER_LOG_DIR="${LOG_DIR}/plotlabserver"
+
+
+clear
+bash plotlabserver/tools/wait_for_plotlab_server.sh
+
+echo ""
+printf "  Waiting for catkin workspace ..."
+until [ -e catkin_workspace/install/setup.sh ]; do
+    printf "."
+    sleep 1
+done
+printf " done \n"
+source catkin_workspace/install/setup.sh
+
+
+
+cd adore_if_ros_demos
+
+for test_scenario in $TEST_SCENARIOS; do
+    if [[ ! -f "${test_scenario}" ]]; then
+        echoerr "ERROR: Specified test scenario: ${test_scenario} is not found."
+    fi
+
+    scenario_name=$(basename $test_scenario .launch)
+    mkdir -p $LOG_DIR/$scenario_name/{plotlabserver,.ros}
+    echo "Running scenario: ${test_scenario}"
+    roslaunch $test_scenario 
+    (cd "${ROS_LOG_DIR}" && ln -s -f $(basename $(file latest | cut -d" " -f6)) latest 2> /dev/null || true)
+    (cd "${ROS_LOG_DIR}" && mv -T latest $scenario_name)
+    cp -r $ROS_LOG_DIR/${scenario_name}/* ${LOG_DIR}/$scenario_name/.ros/
+    cp -r $PLOTLABSERVER_LOG_DIR/* ${LOG_DIR}/$scenario_name/plotlabserver/
+done


### PR DESCRIPTION
- updated plotlabserver submodule
- removed bulk of plotlabserver service definition from docker-compose and used the "extends" docker compose feature so that content in the docker-compose file is not replicated in multiple locations.
- updated libadore and adore_if_ros .dockerignore files
- added make target "run_test_scenarios"
Test scenarios can be defined by modifying the environmental variable in the make file:
```makefile
TEST_SCENARIOS?=baseline_test.launch baseline_test.launch
```
The list is a space separated list of launch files. In this example it is the same scenario twice. Then the provided make target can be run to run automated scenarios:
```bash
make run_test_scenarios
```

For each run scenario a log directory is created in .log/<scenario name> containing all log artifacts.


-split up the adore-cli make target into three targets for code reuse: adore-cli_taredown, adore-cli_setup and adore-cli_start
