### PR TITLE
bugfix: moby/buildkit dockerfile plus library incompatiblity fix

### DIFF
--- a/docker/Dockerfile.adore-cli
+++ b/docker/Dockerfile.adore-cli
@@ -1,5 +1,3 @@
-# syntax = edrevo/dockerfile-plus
-
 ARG USER=adore-cli
 ARG ADORE_IF_ROS_TAG=latest
 ARG USER
@@ -30,8 +28,22 @@ RUN apt-get update && \
 RUN useradd --create-home ${USER}
 
 
-INCLUDE+ docker/Dockerfile.personalize.partial
-INCLUDE+ docker/Dockerfile.zsh.partial
+RUN usermod -u ${UID} ${USER} && groupmod -g ${GID} ${USER}
+RUN chown -r ${UID}:${GID} $$HOME | true
+
+ARG USER
+ARG ZSH_CUSTOM=/home/${USER}/.oh-my-zsh/custom
+
+
+USER root
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y zsh git curl && \
+    rm -rf /var/lib/apt/lists/*
+
+USER ${USER}
+WORKDIR /home/${USER}
+RUN zsh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" ||true
+
 
 USER root
 COPY docker/files/.zshrc /home/${USER}

--- a/docker/Dockerfile.adore-cli_x11_display
+++ b/docker/Dockerfile.adore-cli_x11_display
@@ -1,5 +1,3 @@
-# syntax = edrevo/dockerfile-plus
-
 ARG ADORE_CLI_TAG=latest
 ARG REQUIREMENTS_FILE
 ARG USER


### PR DESCRIPTION
## Bugfix
There is a bug in https://github.com/edrevo/dockerfile-plus which makes it incompatible with newer versions of moby/buildkit. The CLI is broken in docker versions > 24.0.0

## Fix
edrevo/dockerfile-plus is/was used in the runtime layers for the CLI to improve code reuse in dockerfiles.  This plugin is now broken resulting in an error similar to the following:
```text
ERROR: failed to solve: missing provenance for <HASH>
```
This plugin has fallen into obscurity with no changes in >3 years. This fix removes the use of the plugin in the cli runtime context fixing the error.

This bug impacts the ADORe CLI and plotlabserver runtime contexts both of which have been fixed with this pr.

## Related Issues
https://github.com/moby/buildkit/issues/3562
https://github.com/docker/buildx/issues/1583
https://github.com/edrevo/dockerfile-plus/issues/30